### PR TITLE
Sets app to use version 2.1 of the app

### DIFF
--- a/lib/nppes_api.rb
+++ b/lib/nppes_api.rb
@@ -38,7 +38,7 @@ module NPPESApi
   # @param limit [Integer] Limit results, default = 10, max = 200
   # @param skip [Integer] Skip first N results, max = 1000
   def self.search(options = {})
-    options.merge!({address_purpose:""})
+    options.merge!({address_purpose:"", version: "2.1"})
     SearchResults.new(RestClient.get('https://npiregistry.cms.hhs.gov/api', params: options).body)
   end
 end


### PR DESCRIPTION
Does not impact our use.

* v1 is deprecated in June.
* https://npiregistry.cms.hhs.gov/registry/help-api