### PR TITLE
SS-3086: Grab Suffix & Prefix

### DIFF
--- a/lib/nppes_api/basic.rb
+++ b/lib/nppes_api/basic.rb
@@ -10,6 +10,8 @@ module NPPESApi
       :first_name,
       :last_name,
       :middle_name,
+      :name_prefix,
+      :name_suffix,
       :name,
       :gender,
       :sole_proprietor,


### PR DESCRIPTION
Just a quick fix so that the API also can grab suffix & prefix as per this ticket:
https://silversheet.atlassian.net/browse/SS-3086

Looking for any MD provider should get you the prefix of MD. Currently in the process of finding a provider with a suffix.