### PR TITLE
Includes version in API query

### DIFF
--- a/lib/nppes_api.rb
+++ b/lib/nppes_api.rb
@@ -37,8 +37,9 @@ module NPPESApi
   # @param country_code [String] Exactly two characters. If "US" other criteria are required
   # @param limit [Integer] Limit results, default = 10, max = 200
   # @param skip [Integer] Skip first N results, max = 1000
+  # @param version [Float] Identifies the version of the API to use (e.g., 2.0, 2.1).
   def self.search(options = {})
-    options.merge!({address_purpose:""})
+    options.merge!({address_purpose:"", version: 2.1})
     SearchResults.new(RestClient.get('https://npiregistry.cms.hhs.gov/api', params: options).body)
   end
 end

--- a/lib/nppes_api/version.rb
+++ b/lib/nppes_api/version.rb
@@ -1,3 +1,3 @@
 module NPPESApi
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end


### PR DESCRIPTION
* The API now needs a version specified. 2.1 is the newest version and
works with our client > https://npiregistry.cms.hhs.gov/registry/help-api

Once this is merged, I will create a bundle update PR for the Silversheet app.

If you'd like to test, you can pull this branch locally, and change your Silversheet gem file to point at the path of this repo. Then try and search for a provider to add from a facility account.