### PR TITLE
Allow base_url to be specified

### DIFF
--- a/lib/nppes_api.rb
+++ b/lib/nppes_api.rb
@@ -19,10 +19,13 @@ module NPPESApi
     MAILING = 'MAILING'.freeze
   ].freeze
 
+  NPPES_BASE_URL = "https://npiregistry.cms.hhs.gov/api".freeze
+
   # This is the main entry point for searches. Provide params as described below to parameterize the search. Search results can consist
   # of at most 1200 results, and each search can return at most 200 of them. Use the limit and skip parameters as described below to
   # perform pagination of the data.
   # {https://npiregistry.cms.hhs.gov/registry/help-api}
+  # @param base_url [String] API base URL, defaults to NPPES_BASE_URL
   # @param number [Integer] An NPI number to search with. Must be exactly 10 characters
   # @param enumeration_type [String] One of the ENUMERATION_TYPES from above. NPI_1 is an individual search, and NPI_2 is organizations.
   #        Will search across both types if unspecified.
@@ -40,6 +43,7 @@ module NPPESApi
   # @param version [Float] Identifies the version of the API to use (e.g., 2.0, 2.1).
   def self.search(options = {})
     options.merge!({address_purpose:"", version: 2.1})
-    SearchResults.new(RestClient.get('https://npiregistry.cms.hhs.gov/api', params: options).body)
+    base_url = options.delete(:base_url) || NPPES_BASE_URL
+    SearchResults.new(RestClient.get(base_url, params: options).body)
   end
 end

--- a/spec/nppes_api_spec.rb
+++ b/spec/nppes_api_spec.rb
@@ -4,4 +4,32 @@ describe NPPESApi do
   it 'has a version number' do
     expect(NPPESApi::VERSION).not_to be nil
   end
+
+  context "base_url" do
+    it "defaults to NPPES_BASE_URL" do
+      allow(RestClient).to receive(:get).and_return(double("resp", body: "[]"))
+
+      NPPESApi::search({})
+
+      expect(RestClient).to have_received(:get).with(
+        NPPESApi::NPPES_BASE_URL,
+        {
+          params: { address_purpose: "", version: 2.1 },
+        },
+      )
+    end
+
+    it "allows an alternative base_url" do
+      allow(RestClient).to receive(:get).and_return(double("resp", body: "[]"))
+
+      NPPESApi::search({ base_url: "http://foo" })
+
+      expect(RestClient).to have_received(:get).with(
+        "http://foo",
+        {
+          params: { address_purpose: "", version: 2.1 },
+        },
+      )
+    end
+  end
 end


### PR DESCRIPTION
Allows compatible backends to be swapped with NPPES

_QA_
Check the specs
_and / or_
```sh
irb(main):001:0> require 'nppes_api.rb'
=> true
irb(main):002:0> NPPESApi.search(number: 1407859325)
=> #<NPPESApi::SearchResults:0x00007fc9f3af7bd8 @data={"result_count"=>1, "results"=>[{"enumeration_type"=>"NPI-1", "number"=>1407859325, "last_updated_epoch"=>1236816000, "created_epoch"=>1116892800, "basic"=>{"name_prefix"=>"DR.", "first_name"=>"FRANK", "last_name"=>"WINN", "middle_name"=>"O.", "credential"=>"D.D.S.", "sole_proprietor"=>"YES", "gender"=>"M", "enumeration_date"=>"2005-05-24", "last_updated"=>"2009-03-12", "status"=>"A", "name"=>"WINN FRANK"}, "other_names"=>[], "addresses"=>[{"country_code"=>"US", "country_name"=>"United States", "address_purpose"=>"LOCATION", "address_type"=>"DOM", "address_1"=>"4551 GAUTIER VANCLEAVE RD", "address_2"=>"STE A", "city"=>"GAUTIER", "state"=>"MS", "postal_code"=>"395534810", "telephone_number"=>"228-497-6110", "fax_number"=>"228-497-7092"}, {"country_code"=>"US", "country_name"=>"United States", "address_purpose"=>"MAILING", "address_type"=>"DOM", "address_1"=>"4551 GAUTIER VANCLEAVE RD", "address_2"=>"STE A", "city"=>"GAUTIER", "state"=>"MS", "postal_code"=>"395534810", "telephone_number"=>"228-497-6110", "fax_number"=>"228-497-7092"}], "taxonomies"=>[{"code"=>"1223G0001X", "desc"=>"Dentist General Practice", "primary"=>true, "state"=>"MS", "license"=>"1917-80"}], "identifiers"=>[{"identifier"=>"41474", "code"=>"01", "desc"=>"Other", "state"=>"MS", "issuer"=>"UNITED CONCORDIA"}]}]}>
irb(main):003:0> NPPESApi.search(base_url: "http://localhost:5000", number: 1407859325)
<local Silversheet is angry>
```